### PR TITLE
Add open source repo hygiene and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owner for the whole repository
+* @qKitNp
+
+# Backend / native surface
+/src-tauri/ @qKitNp
+
+# CI and repo automation
+/.github/ @qKitNp

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Something isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. For security issues, use [private reporting](https://github.com/qKitNp/grammar-lol/security/advisories/new) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+      placeholder: Clear, concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the problem.
+      placeholder: |
+        1. Open …
+        2. Select text …
+        3. Double-tap Right Shift …
+        4. See error …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Multiple / unknown
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version or commit
+      description: Release tag or git commit if known.
+  - type: dropdown
+    id: provider
+    attributes:
+      label: AI provider
+      options:
+        - ChatGPT
+        - SuperGrok
+        - Not signed in / n/a
+        - Both / unknown
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste relevant logs (redact tokens). Screenshots welcome.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true
+        - label: I redacted any secrets or personal data from this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/qKitNp/grammar-lol/security/advisories/new
+    about: Please report security issues privately (see SECURITY.md). Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an idea for Grammar.lol
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? Who benefits?
+      placeholder: As a user, I want …
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or existing workarounds.
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Target platforms
+      multiple: true
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - All
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Related issues
+
+<!-- e.g. Fixes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / chore
+- [ ] Documentation
+- [ ] CI / repo config
+
+## Testing
+
+- [ ] Ran `bun run build` (TypeScript + Vite)
+- [ ] Ran `bun run tauri dev` (or full build) on my machine
+- [ ] Manual smoke test of the change
+
+**Platforms tested:** <!-- macOS / Windows / Linux / n/a -->
+
+## Checklist
+
+- [ ] I did not commit secrets, tokens, or personal credentials
+- [ ] PR description is clear enough for review
+- [ ] Linked related issues (if any)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      production-npm:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-npm:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      rust-deps:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,46 @@ name: Build Tauri App
 on:
   push:
     branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: windows-latest
+    name: Build (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            os: windows-latest
+            artifact: windows-build
+          - platform: macos
+            os: macos-latest
+            artifact: macos-build
+          - platform: linux
+            os: ubuntu-latest
+            artifact: linux-build
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -22,7 +50,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install dependencies
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 
       - name: Build Tauri
@@ -31,5 +64,8 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windows-build
-          path: src-tauri/target/release/bundle/
+          name: ${{ matrix.artifact }}
+          path: |
+            src-tauri/target/release/bundle/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            build-essential \
+            curl \
+            wget \
+            file \
             libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
             librsvg2-dev \
             patchelf \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            libxdo-dev \
+            libasound2-dev
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (tsc + vite)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck and build frontend
+        run: bun run build
+
+  rust-check:
+    name: Rust check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Tauri / Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: cargo check
+        working-directory: src-tauri
+        run: cargo check --all-targets
+
+      - name: cargo clippy
+        working-directory: src-tauri
+        run: cargo clippy --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            build-essential \
+            curl \
+            wget \
+            file \
             libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
             librsvg2-dev \
             patchelf \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            libxdo-dev \
+            libasound2-dev
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**pranjal19@pm.me**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Grammar.lol
+
+Thanks for helping improve Grammar.lol. This guide covers setup, workflow, and what makes a good contribution.
+
+## Code of conduct
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development setup
+
+### Requirements
+
+- [Bun](https://bun.sh)
+- [Rust toolchain](https://rustup.rs) (stable)
+- Platform build tools:
+  - **macOS:** Xcode Command Line Tools
+  - **Windows:** Visual Studio Build Tools (C++ workload)
+  - **Linux:** WebKitGTK and other [Tauri Linux dependencies](https://v2.tauri.app/start/prerequisites/)
+
+### Run locally
+
+```bash
+bun install
+bun run tauri dev
+```
+
+### Build
+
+```bash
+bun run tauri build
+```
+
+### Frontend-only checks
+
+```bash
+bun run build   # tsc + vite build
+```
+
+## How we work
+
+1. **Open an issue first** for non-trivial changes (features, behavior changes, larger refactors). Small docs/typo fixes can go straight to a PR.
+2. **Fork and branch** from `main` (e.g. `fix/short-description` or `feat/short-description`).
+3. **Keep PRs focused** — one concern per PR when practical.
+4. **Do not commit secrets** — OAuth tokens, `.env`, `auth.json`, keys, or personal credentials. See `.gitignore`.
+5. **Test on your platform** before requesting review. Note in the PR what you tested (macOS / Windows / Linux).
+
+## Pull requests
+
+- Fill out the PR template.
+- Ensure CI is green (typecheck / lint checks on PRs; full Tauri builds may run on `main`).
+- Prefer clear commit messages that explain *why*.
+- Link related issues (`Fixes #123`).
+
+## Project layout
+
+| Path | Role |
+|------|------|
+| `src/` | React + TypeScript UI |
+| `src-tauri/` | Rust / Tauri backend |
+| `plugins/` | Vite plugins (e.g. OAuth bridge) |
+| `.github/` | CI, templates, Dependabot |
+
+## License
+
+By contributing, you agree that your contributions are licensed under the [GNU General Public License v3.0](LICENSE) (GPL-3.0-only), the same license as the project.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ src-tauri/target/release/bundle/macos/Grammar.lol.app
 - SQLite (local ledger)
 - ChatGPT Codex OAuth / xAI SuperGrok device-code OAuth
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Please read the [Code of Conduct](CODE_OF_CONDUCT.md) and report security issues via [SECURITY.md](SECURITY.md).
+
 ## License
 
 [GNU General Public License v3.0](LICENSE) (GPL-3.0-only).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest code on `main`. If you are running a release build, upgrade to the newest release when one is available.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report privately using one of:
+
+1. **[GitHub private vulnerability reporting](https://github.com/qKitNp/grammar-lol/security/advisories/new)** (preferred)
+2. Email: **pranjal19@pm.me** (subject: `grammar-lol security`)
+
+Include as much detail as you can:
+
+- Description of the issue and impact
+- Steps to reproduce, or a proof of concept
+- Affected platform (macOS / Windows / Linux) and app version or commit
+- Whether the issue involves secrets, OAuth tokens, local data, or remote code paths
+
+## What to expect
+
+- Acknowledgement within a few days when possible
+- A fix or mitigation plan for confirmed issues
+- Credit in the advisory or release notes if you want it (optional)
+
+## Scope notes
+
+Grammar.lol stores OAuth tokens and proof history locally and talks only to the AI provider you sign in with (OpenAI / xAI). Reports involving token storage, IPC/accessibility surface area, dependency supply chain, or accidental secret leakage are especially welcome.
+
+Please do not intentionally access other users’ accounts or production systems that are not yours.


### PR DESCRIPTION
## Summary

Sets up standard open-source configuration for Grammar.lol:

- **Community:** `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue/PR templates, `CODEOWNERS`
- **Automation:** Dependabot (npm, cargo, GitHub Actions), CodeQL, PR CI (frontend build + Rust check/clippy)
- **Builds:** Multi-platform Tauri build on `main`/tags (Windows, macOS, Linux)
- **Repo settings (already applied via API):** branch protection on `main`, squash-only merges, delete head branches, topics, Dependabot security updates, wiki/projects off

## Test plan

- [ ] CI jobs `Frontend (tsc + vite)` and `Rust check` pass on this PR
- [ ] CodeQL workflow starts successfully
- [ ] After merge, Dependabot opens update PRs on schedule