### PR TITLE
docs: prefer npm/npx for install and Tauri builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,11 @@ jobs:
             libxdo-dev \
             libasound2-dev
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -62,10 +65,10 @@ jobs:
           workspaces: src-tauri
 
       - name: Install frontend dependencies
-        run: bun install --frozen-lockfile
+        run: npm install
 
       - name: Build Tauri
-        run: bun run tauri build
+        run: npx tauri build
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ Pick one provider during onboarding. Switch later in **Settings → Account**. C
 ## Develop
 
 ```bash
-bun install
-bun run tauri dev
+npm install
+npx tauri dev
 ```
 
-Requirements: Rust toolchain, platform build tools (Xcode CLT on macOS), [Bun](https://bun.sh).
+Requirements: Node.js (npm), Rust toolchain, platform build tools (Xcode CLT on macOS). Bun works too if you prefer.
 
 ## Build
 
 ```bash
-bun run tauri build
+npm install
+npx tauri build
 ```
 
 macOS app output:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "com.kitn.grammar-lol",
   "build": {
-    "beforeDevCommand": "bun run dev",
+    "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "bun run build",
+    "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
   "app": {


### PR DESCRIPTION
## Summary
- Switch Tauri `beforeDevCommand` / `beforeBuildCommand` from Bun to npm
- Update README to document `npm install` + `npx tauri build` / `npx tauri dev`
- CI uses Node/npm instead of Bun so it matches the documented path

## Test plan
- [ ] CI build passes on the PR
- [ ] `npm install && npx tauri build` works locally