### PR TITLE
Add on-device Apple Intelligence proofreading provider

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,3 +41,5 @@ rdev = "0.5"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 core-graphics = "0.24"
+# On-device Apple Intelligence is bridged via swift-bridge/ + build.rs
+# (not the foundation-models crate — that needs a newer Xcode SDK).

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,103 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    #[cfg(target_os = "macos")]
+    build_apple_intelligence_bridge();
+}
+
+#[cfg(target_os = "macos")]
+fn build_apple_intelligence_bridge() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let swift_src = manifest_dir.join("swift-bridge/AppleIntelligenceBridge.swift");
+    println!("cargo:rerun-if-changed={}", swift_src.display());
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let lib_path = out_dir.join("libAppleIntelligenceBridge.a");
+
+    let sdk = Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+        .expect("xcrun --sdk macosx --show-sdk-path");
+    assert!(
+        sdk.status.success(),
+        "failed to resolve macOS SDK path via xcrun"
+    );
+    let sdk_path = String::from_utf8_lossy(&sdk.stdout).trim().to_string();
+
+    // Target the host triple so the archive links cleanly into the Tauri binary.
+    let target = env::var("TARGET").unwrap_or_else(|_| "aarch64-apple-darwin".into());
+    let arch = if target.starts_with("x86_64") {
+        "x86_64"
+    } else {
+        "arm64"
+    };
+
+    let status = Command::new("xcrun")
+        .args([
+            "swiftc",
+            "-parse-as-library",
+            "-emit-library",
+            "-static",
+            "-O",
+            "-module-name",
+            "AppleIntelligenceBridge",
+            "-sdk",
+            &sdk_path,
+            "-target",
+            &format!("{arch}-apple-macos26.0"),
+            "-framework",
+            "FoundationModels",
+            "-framework",
+            "Foundation",
+            "-o",
+            lib_path.to_str().unwrap(),
+            swift_src.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to invoke swiftc for AppleIntelligenceBridge");
+
+    assert!(
+        status.success(),
+        "swiftc failed building AppleIntelligenceBridge (need Xcode 26+ with FoundationModels)"
+    );
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=AppleIntelligenceBridge");
+    println!("cargo:rustc-link-lib=framework=FoundationModels");
+    println!("cargo:rustc-link-lib=framework=Foundation");
+    println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    println!("cargo:rustc-link-lib=framework=Security");
+
+    // Static Swift archives pull in swiftCore / swift_Concurrency via autolink,
+    // but rustc does not add the OS / Xcode Swift runtime search paths or rpaths.
+    // Without these, dyld fails at launch with:
+    //   Library not loaded: @rpath/libswift_Concurrency.dylib
+    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+
+    if let Ok(output) = Command::new("xcode-select").arg("-p").output() {
+        if output.status.success() {
+            let xcode = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let swift_macosx = format!(
+                "{xcode}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"
+            );
+            let swift55_macosx = format!(
+                "{xcode}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
+            );
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{swift_macosx}");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{swift55_macosx}");
+            println!("cargo:rustc-link-search=native={swift_macosx}");
+            println!("cargo:rustc-link-search=native={swift55_macosx}");
+        }
+    }
+
+    println!("cargo:rustc-link-search=native={sdk_path}/usr/lib/swift");
+    // Prefer absolute install names under /usr/lib/swift when the linker can
+    // resolve them (matches pure-Swift binaries). Keep explicit link of the
+    // concurrency runtime so the load command is present and rpath-backed.
+    println!("cargo:rustc-link-lib=swiftCore");
+    println!("cargo:rustc-link-lib=swift_Concurrency");
 }

--- a/src-tauri/src/apple_intelligence.rs
+++ b/src-tauri/src/apple_intelligence.rs
@@ -1,0 +1,124 @@
+//! On-device Apple Intelligence (Foundation Models) via a tiny Swift bridge.
+//!
+//! We use a local `swift-bridge/AppleIntelligenceBridge.swift` instead of the
+//! `foundation-models` crates.io crate, which currently requires a newer Xcode
+//! SDK (26.4+/26.5) than many machines still ship.
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::ptr;
+
+use serde::Serialize;
+
+#[link(name = "AppleIntelligenceBridge", kind = "static")]
+unsafe extern "C" {
+    fn gl_ai_is_available() -> bool;
+    fn gl_ai_availability_code() -> i32;
+    fn gl_ai_string_free(ptr: *mut c_char);
+    fn gl_ai_proofread(
+        instructions: *const c_char,
+        prompt: *const c_char,
+        out_error: *mut *mut c_char,
+    ) -> *mut c_char;
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Status {
+    pub supported: bool,
+    pub available: bool,
+    pub reason: Option<String>,
+}
+
+fn free_c_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe { gl_ai_string_free(ptr) };
+    }
+}
+
+fn take_c_string(ptr: *mut c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let s = unsafe { CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .into_owned();
+    free_c_string(ptr);
+    s
+}
+
+pub fn status() -> Status {
+    let code = unsafe { gl_ai_availability_code() };
+    if unsafe { gl_ai_is_available() } {
+        return Status {
+            supported: true,
+            available: true,
+            reason: None,
+        };
+    }
+    let reason = match code {
+        1 => Some(
+            "This Mac is not eligible for Apple Intelligence (Apple Silicon required)."
+                .to_string(),
+        ),
+        2 => Some(
+            "Apple Intelligence is not enabled. Turn it on in System Settings.".to_string(),
+        ),
+        3 => Some(
+            "The on-device model is still downloading or not ready. Try again in a moment."
+                .to_string(),
+        ),
+        -1 => Some(
+            "macOS 26 or newer is required for on-device Apple Intelligence.".to_string(),
+        ),
+        _ => Some("Apple Intelligence is unavailable on this Mac.".to_string()),
+    };
+    Status {
+        supported: true,
+        available: false,
+        reason,
+    }
+}
+
+pub fn is_available() -> bool {
+    unsafe { gl_ai_is_available() }
+}
+
+/// Run a single-shot proofread with system instructions. Blocking.
+pub fn proofread(instructions: &str, text: &str) -> Result<String, String> {
+    if !is_available() {
+        let st = status();
+        return Err(st.reason.unwrap_or_else(|| {
+            "Apple Intelligence is not available. Enable it in System Settings.".into()
+        }));
+    }
+
+    let instructions_c =
+        CString::new(instructions).map_err(|_| "instructions contain interior NUL".to_string())?;
+    let prompt_c = CString::new(text).map_err(|_| "text contains interior NUL".to_string())?;
+
+    let mut err_ptr: *mut c_char = ptr::null_mut();
+    let result_ptr = unsafe {
+        gl_ai_proofread(
+            instructions_c.as_ptr(),
+            prompt_c.as_ptr(),
+            &mut err_ptr as *mut *mut c_char,
+        )
+    };
+
+    if result_ptr.is_null() {
+        let msg = if err_ptr.is_null() {
+            "Apple Intelligence returned no result".to_string()
+        } else {
+            take_c_string(err_ptr)
+        };
+        return Err(format!("Apple Intelligence: {msg}"));
+    }
+
+    let out = take_c_string(result_ptr);
+    if out.trim().is_empty() {
+        return Err("Apple Intelligence returned empty correction".into());
+    }
+    Ok(out)
+}

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -1,7 +1,9 @@
-//! Session storage + ChatGPT / SuperGrok OAuth.
+//! Session storage + ChatGPT / SuperGrok OAuth + local Apple Intelligence.
 //!
 //! Tokens live in the app config dir (mode 0600). Proofread calls live in
 //! [`crate::inference`] and pull tokens from here.
+//!
+//! Apple Intelligence uses a tokenless session marker — no network OAuth.
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use parking_lot::Mutex;
@@ -31,6 +33,7 @@ const XAI_DEVICE_CODE_URL: &str = "https://auth.x.ai/oauth2/device/code";
 const XAI_TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
 const XAI_SCOPE: &str = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
 const XAI_DEFAULT_MODEL: &str = "grok-4.20-0309-non-reasoning";
+const APPLE_DEFAULT_MODEL: &str = "apple-intelligence";
 
 /// Curated models for ChatGPT subscription (Codex) surface.
 /// Availability depends on plan; the API will reject unsupported slugs.
@@ -53,6 +56,11 @@ const XAI_MODELS: &[(&str, &str)] = &[
     ("grok-build-0.1", "Grok Build 0.1"),
 ];
 
+const APPLE_MODELS: &[(&str, &str)] = &[(
+    APPLE_DEFAULT_MODEL,
+    "On-device (Apple Intelligence)",
+)];
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -60,6 +68,7 @@ const XAI_MODELS: &[(&str, &str)] = &[
 pub enum ProviderId {
     Chatgpt,
     Xai,
+    AppleIntelligence,
 }
 
 impl ProviderId {
@@ -67,7 +76,13 @@ impl ProviderId {
         match self {
             ProviderId::Chatgpt => "ChatGPT",
             ProviderId::Xai => "SuperGrok",
+            ProviderId::AppleIntelligence => "Apple Intelligence",
         }
+    }
+
+    /// True when this provider does not use OAuth tokens.
+    pub fn is_local(&self) -> bool {
+        matches!(self, ProviderId::AppleIntelligence)
     }
 }
 
@@ -126,6 +141,17 @@ pub struct XaiDeviceStart {
     pub verification_uri_complete: Option<String>,
     pub interval: u64,
     pub expires_in: u64,
+}
+
+/// Runtime status of the on-device Apple Intelligence model.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppleIntelligenceStatus {
+    /// Compile + platform support (macOS target of this binary).
+    pub supported: bool,
+    /// Model is ready to run right now.
+    pub available: bool,
+    /// Human-readable reason when not available.
+    pub reason: Option<String>,
 }
 
 /// In-flight SuperGrok device-code state (held in memory only).
@@ -200,6 +226,7 @@ fn models_for(provider: &ProviderId) -> &'static [(&'static str, &'static str)] 
     match provider {
         ProviderId::Chatgpt => CHATGPT_MODELS,
         ProviderId::Xai => XAI_MODELS,
+        ProviderId::AppleIntelligence => APPLE_MODELS,
     }
 }
 
@@ -207,6 +234,7 @@ fn default_model(provider: &ProviderId) -> &'static str {
     match provider {
         ProviderId::Chatgpt => CHATGPT_DEFAULT_MODEL,
         ProviderId::Xai => XAI_DEFAULT_MODEL,
+        ProviderId::AppleIntelligence => APPLE_DEFAULT_MODEL,
     }
 }
 
@@ -219,10 +247,33 @@ pub(crate) fn selected_model(app: &AppHandle, provider: &ProviderId) -> String {
     let stored = match provider {
         ProviderId::Chatgpt => prefs.chatgpt_model.as_deref(),
         ProviderId::Xai => prefs.xai_model.as_deref(),
+        ProviderId::AppleIntelligence => Some(APPLE_DEFAULT_MODEL),
     };
     match stored {
         Some(m) if is_known_model(provider, m) => m.to_string(),
         _ => default_model(provider).to_string(),
+    }
+}
+
+fn apple_intelligence_status_inner() -> AppleIntelligenceStatus {
+    #[cfg(target_os = "macos")]
+    {
+        let st = crate::apple_intelligence::status();
+        AppleIntelligenceStatus {
+            supported: st.supported,
+            available: st.available,
+            reason: st.reason,
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        AppleIntelligenceStatus {
+            supported: false,
+            available: false,
+            reason: Some(
+                "Apple Intelligence is only available on macOS 26+ with Apple Silicon.".into(),
+            ),
+        }
     }
 }
 
@@ -310,6 +361,9 @@ fn now_unix() -> i64 {
 }
 
 pub(crate) fn is_expired(session: &AuthSession) -> bool {
+    if session.provider.is_local() {
+        return false;
+    }
     let exp = if session.expires_at > 0 {
         session.expires_at
     } else {
@@ -388,7 +442,9 @@ fn apply_token_response(
             .map(|s| s.to_string())
             .or_else(|| chatgpt_account_id_from_token(&access))
             .or_else(|| prev.and_then(|p| p.account_id.clone())),
-        ProviderId::Xai => prev.and_then(|p| p.account_id.clone()),
+        ProviderId::Xai | ProviderId::AppleIntelligence => {
+            prev.and_then(|p| p.account_id.clone())
+        }
     };
 
     let label = email_from_id_token(id_token.as_deref())
@@ -406,6 +462,9 @@ fn apply_token_response(
 }
 
 pub(crate) fn refresh_session(app: &AppHandle, session: &AuthSession) -> Result<AuthSession, String> {
+    if session.provider.is_local() {
+        return Ok(session.clone());
+    }
     let json = match session.provider {
         ProviderId::Chatgpt => form_post(
             CHATGPT_TOKEN_URL,
@@ -423,6 +482,7 @@ pub(crate) fn refresh_session(app: &AppHandle, session: &AuthSession) -> Result<
                 ("client_id", XAI_CLIENT_ID),
             ],
         )?,
+        ProviderId::AppleIntelligence => return Ok(session.clone()),
     };
     let next = apply_token_response(session.provider.clone(), &json, Some(session))?;
     save_session(app, &next)?;
@@ -590,8 +650,13 @@ pub fn get_model_settings(app: AppHandle) -> Result<ModelSettings, String> {
 #[tauri::command]
 pub fn set_model(app: AppHandle, model: String) -> Result<ModelSettings, String> {
     let session = load_session(&app)?.ok_or_else(|| {
-        "Not signed in. Connect ChatGPT or SuperGrok before choosing a model.".to_string()
+        "Not signed in. Connect ChatGPT, SuperGrok, or Apple Intelligence before choosing a model."
+            .to_string()
     })?;
+    if session.provider.is_local() {
+        // Single fixed on-device model — nothing to persist.
+        return get_model_settings(app);
+    }
     if !is_known_model(&session.provider, &model) {
         return Err(format!(
             "Unknown model for {}: {model}",
@@ -602,9 +667,52 @@ pub fn set_model(app: AppHandle, model: String) -> Result<ModelSettings, String>
     match session.provider {
         ProviderId::Chatgpt => prefs.chatgpt_model = Some(model),
         ProviderId::Xai => prefs.xai_model = Some(model),
+        ProviderId::AppleIntelligence => {}
     }
     save_prefs(&app, &prefs)?;
     get_model_settings(app)
+}
+
+/// Report whether the on-device Apple Intelligence model can run.
+#[tauri::command]
+pub fn apple_intelligence_status() -> AppleIntelligenceStatus {
+    apple_intelligence_status_inner()
+}
+
+/// Activate the local Apple Intelligence provider (no OAuth).
+#[tauri::command]
+pub fn apple_intelligence_enable(app: AppHandle) -> Result<AuthStatus, String> {
+    let status = apple_intelligence_status_inner();
+    if !status.supported {
+        return Err(status
+            .reason
+            .unwrap_or_else(|| "Apple Intelligence is not supported on this platform.".into()));
+    }
+    if !status.available {
+        return Err(status.reason.unwrap_or_else(|| {
+            "Apple Intelligence is not available. Enable it in System Settings.".into()
+        }));
+    }
+
+    let session = AuthSession {
+        provider: ProviderId::AppleIntelligence,
+        // Tokenless marker session — never sent on the wire.
+        access_token: String::new(),
+        refresh_token: String::new(),
+        id_token: None,
+        account_id: None,
+        label: Some("On this Mac".into()),
+        expires_at: 0,
+    };
+    save_session(&app, &session)?;
+    let model = selected_model(&app, &ProviderId::AppleIntelligence);
+    Ok(AuthStatus {
+        signed_in: true,
+        provider: Some(ProviderId::AppleIntelligence),
+        label: session.label,
+        provider_label: Some(ProviderId::AppleIntelligence.label().to_string()),
+        model: Some(model),
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/inference.rs
+++ b/src-tauri/src/inference.rs
@@ -1,4 +1,5 @@
-//! Proofread inference against ChatGPT / SuperGrok Responses APIs.
+//! Proofread inference against ChatGPT / SuperGrok Responses APIs,
+//! or the on-device Apple Intelligence (Foundation Models) path.
 //!
 //! Runs in the Tauri backend so the frontend never needs CORS exceptions.
 //! Auth (tokens + model choice) comes from [`crate::auth`].
@@ -282,15 +283,33 @@ fn call_xai_responses(session: &AuthSession, text: &str, model: &str) -> Result<
     extract_output_text(&json)
 }
 
+/// On-device proofread via Apple Foundation Models (Apple Intelligence).
+#[cfg(target_os = "macos")]
+fn call_apple_intelligence(text: &str) -> Result<String, String> {
+    // Fresh session per call is handled inside the Swift bridge so prior turns
+    // never consume the ~4k context window.
+    crate::apple_intelligence::proofread(SYSTEM_PROMPT, text).map(|s| s.trim().to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn call_apple_intelligence(_text: &str) -> Result<String, String> {
+    Err("Apple Intelligence is only available on macOS 26+ with Apple Silicon.".into())
+}
+
 fn proofread_with_session(
     app: &AppHandle,
     session: AuthSession,
     text: &str,
 ) -> Result<String, String> {
+    if session.provider == ProviderId::AppleIntelligence {
+        return call_apple_intelligence(text);
+    }
+
     let model = selected_model(app, &session.provider);
     let result = match session.provider {
         ProviderId::Chatgpt => call_chatgpt_responses(&session, text, &model),
         ProviderId::Xai => call_xai_responses(&session, text, &model),
+        ProviderId::AppleIntelligence => unreachable!("handled above"),
     };
 
     match result {
@@ -300,6 +319,7 @@ fn proofread_with_session(
             match refreshed.provider {
                 ProviderId::Chatgpt => call_chatgpt_responses(&refreshed, text, &model),
                 ProviderId::Xai => call_xai_responses(&refreshed, text, &model),
+                ProviderId::AppleIntelligence => call_apple_intelligence(text),
             }
         }
         other => other,
@@ -312,9 +332,11 @@ pub async fn proofread_text(app: AppHandle, text: String) -> Result<String, Stri
     let app2 = app.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let mut session = load_session(&app2)?.ok_or_else(|| {
-            "Not signed in. Open Settings and connect ChatGPT or SuperGrok.".to_string()
+            "Not signed in. Open Settings and connect ChatGPT, SuperGrok, or Apple Intelligence."
+                .to_string()
         })?;
-        if is_expired(&session) {
+        // Local provider has no tokens to refresh.
+        if session.provider != ProviderId::AppleIntelligence && is_expired(&session) {
             session = refresh_session(&app2, &session)?;
         }
         proofread_with_session(&app2, session, &text)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_sql::{Migration, MigrationKind};
 
 mod auth;
+#[cfg(target_os = "macos")]
+mod apple_intelligence;
 mod doubletap;
 mod inference;
 mod sound;
@@ -324,6 +326,8 @@ pub fn run() {
             auth::xai_poll_login,
             auth::get_model_settings,
             auth::set_model,
+            auth::apple_intelligence_status,
+            auth::apple_intelligence_enable,
             inference::proofread_text,
         ]);
 

--- a/src-tauri/swift-bridge/AppleIntelligenceBridge.swift
+++ b/src-tauri/swift-bridge/AppleIntelligenceBridge.swift
@@ -1,0 +1,122 @@
+import Foundation
+import FoundationModels
+
+// Minimal C-callable bridge for Grammar.lol on-device proofreading.
+// Targets the macOS 26.0 FoundationModels surface (no 26.4+ APIs).
+
+@_cdecl("gl_ai_is_available")
+public func gl_ai_is_available() -> Bool {
+    if #available(macOS 26.0, *) {
+        if case .available = SystemLanguageModel.default.availability {
+            return true
+        }
+    }
+    return false
+}
+
+/// 0 = available
+/// 1 = deviceNotEligible
+/// 2 = appleIntelligenceNotEnabled
+/// 3 = modelNotReady
+/// -1 = os too old / unavailable on this build
+/// -2 = other / unknown
+@_cdecl("gl_ai_availability_code")
+public func gl_ai_availability_code() -> Int32 {
+    if #available(macOS 26.0, *) {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return 0
+        case .unavailable(.deviceNotEligible):
+            return 1
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return 2
+        case .unavailable(.modelNotReady):
+            return 3
+        default:
+            return -2
+        }
+    }
+    return -1
+}
+
+/// Free a string returned by this bridge.
+@_cdecl("gl_ai_string_free")
+public func gl_ai_string_free(_ ptr: UnsafeMutablePointer<CChar>?) {
+    free(ptr)
+}
+
+private func dupCString(_ s: String) -> UnsafeMutablePointer<CChar>? {
+    s.withCString { strdup($0) }
+}
+
+/// Blocking proofread: system instructions + user text → corrected text.
+/// On success returns a heap string (caller must free with gl_ai_string_free).
+/// On failure returns null and writes an error string into out_error (also free).
+@_cdecl("gl_ai_proofread")
+public func gl_ai_proofread(
+    _ instructions: UnsafePointer<CChar>?,
+    _ prompt: UnsafePointer<CChar>?,
+    _ out_error: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> UnsafeMutablePointer<CChar>? {
+    guard let prompt else {
+        if let out_error {
+            out_error.pointee = dupCString("empty prompt")
+        }
+        return nil
+    }
+    let promptStr = String(cString: prompt)
+    let instructionsStr: String? = instructions.map { String(cString: $0) }
+
+    if #available(macOS 26.0, *) {
+        // FoundationModels APIs are async; block the caller with a semaphore.
+        final class Box: @unchecked Sendable {
+            var text: String?
+            var error: String?
+        }
+        let box = Box()
+        let sem = DispatchSemaphore(value: 0)
+
+        Task {
+            do {
+                let session: LanguageModelSession
+                if let instructionsStr, !instructionsStr.isEmpty {
+                    session = LanguageModelSession(instructions: instructionsStr)
+                } else {
+                    session = LanguageModelSession()
+                }
+                let response = try await session.respond(to: promptStr)
+                box.text = response.content
+            } catch {
+                box.error = String(describing: error)
+            }
+            sem.signal()
+        }
+
+        // Cap wait so a stuck model can't hang the app forever.
+        let wait = sem.wait(timeout: .now() + 120)
+        if wait == .timedOut {
+            if let out_error {
+                out_error.pointee = dupCString("Apple Intelligence timed out after 120s")
+            }
+            return nil
+        }
+        if let err = box.error {
+            if let out_error {
+                out_error.pointee = dupCString(err)
+            }
+            return nil
+        }
+        guard let text = box.text else {
+            if let out_error {
+                out_error.pointee = dupCString("empty response from Apple Intelligence")
+            }
+            return nil
+        }
+        return dupCString(text)
+    }
+
+    if let out_error {
+        out_error.pointee = dupCString("macOS 26+ required for Apple Intelligence")
+    }
+    return nil
+}

--- a/src/components/onboarding/StepAccountLogin.tsx
+++ b/src/components/onboarding/StepAccountLogin.tsx
@@ -3,9 +3,12 @@ import { motion } from "motion/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   cancelChatgptLogin,
+  enableAppleIntelligence,
+  getAppleIntelligenceStatus,
   loginWithChatgpt,
   startXaiLogin,
   waitForXaiLogin,
+  type AppleIntelligenceStatus,
   type ProviderId,
 } from "../../lib/auth";
 
@@ -17,9 +20,19 @@ type Phase =
 
 export function StepAccountLogin({ onNext }: { onNext: () => void }) {
   const [phase, setPhase] = useState<Phase>({ kind: "pick" });
+  const [apple, setApple] = useState<AppleIntelligenceStatus | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    getAppleIntelligenceStatus()
+      .then(setApple)
+      .catch(() =>
+        setApple({
+          supported: false,
+          available: false,
+          reason: "Could not check Apple Intelligence status.",
+        }),
+      );
     return () => {
       abortRef.current?.abort();
     };
@@ -73,6 +86,20 @@ export function StepAccountLogin({ onNext }: { onNext: () => void }) {
     }
   }
 
+  async function handleApple() {
+    abortRef.current?.abort();
+    try {
+      await enableAppleIntelligence();
+      onNext();
+    } catch (e) {
+      setPhase({
+        kind: "error",
+        provider: "apple_intelligence",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
   async function openVerification(uri: string) {
     try {
       await openUrl(uri);
@@ -91,16 +118,28 @@ export function StepAccountLogin({ onNext }: { onNext: () => void }) {
     >
       <div>
         <h1 className="text-[26px] font-medium tracking-tight leading-tight">
-          Connect your account
+          Choose a proofreading engine
         </h1>
         <p className="mt-3 text-[13.5px] text-[var(--text-soft)] leading-relaxed">
-          Grammar.lol uses your ChatGPT or SuperGrok subscription for corrections.
+          Use on-device Apple Intelligence, or your ChatGPT / SuperGrok subscription.
           Your writing is never sent to a Grammar.lol server.
         </p>
       </div>
 
       {phase.kind === "pick" && (
         <div className="flex flex-col gap-3 w-full">
+          {apple?.supported && (
+            <ProviderButton
+              title="Continue with Apple Intelligence"
+              subtitle={
+                apple.available
+                  ? "On-device · free · private"
+                  : (apple.reason ?? "Not available right now")
+              }
+              onClick={handleApple}
+              disabled={!apple.available}
+            />
+          )}
           <ProviderButton
             title="Continue with ChatGPT"
             subtitle="Works with Free, Go, Plus, and Pro plans"
@@ -183,15 +222,18 @@ function ProviderButton({
   title,
   subtitle,
   onClick,
+  disabled,
 }: {
   title: string;
   subtitle: string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       onClick={onClick}
-      className="w-full text-left px-5 py-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] transition-colors cursor-pointer"
+      disabled={disabled}
+      className="w-full text-left px-5 py-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] transition-colors cursor-pointer disabled:opacity-50 disabled:hover:border-[var(--border)] disabled:cursor-not-allowed"
     >
       <div className="text-[14px] font-medium text-[var(--text)]">{title}</div>
       <div className="text-[12px] text-[var(--text-soft)] mt-0.5">{subtitle}</div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
-export type ProviderId = "chatgpt" | "xai";
+export type ProviderId = "chatgpt" | "xai" | "apple_intelligence";
 
 export type AuthStatus = {
   signed_in: boolean;
@@ -27,6 +27,12 @@ export type XaiDeviceStart = {
   verification_uri_complete: string | null;
   interval: number;
   expires_in: number;
+};
+
+export type AppleIntelligenceStatus = {
+  supported: boolean;
+  available: boolean;
+  reason: string | null;
 };
 
 export async function getAuthStatus(): Promise<AuthStatus> {
@@ -62,6 +68,16 @@ export async function startXaiLogin(): Promise<XaiDeviceStart> {
 /** Poll once. Returns status when complete, null if still pending. */
 export async function pollXaiLogin(): Promise<AuthStatus | null> {
   return invoke<AuthStatus | null>("xai_poll_login");
+}
+
+/** Whether the on-device Apple Intelligence model can run. */
+export async function getAppleIntelligenceStatus(): Promise<AppleIntelligenceStatus> {
+  return invoke<AppleIntelligenceStatus>("apple_intelligence_status");
+}
+
+/** Activate local Apple Intelligence (no OAuth). */
+export async function enableAppleIntelligence(): Promise<AuthStatus> {
+  return invoke<AuthStatus>("apple_intelligence_enable");
 }
 
 export async function waitForXaiLogin(

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { ONBOARDING_FLAG } from "./Onboarding";
 import {
+  enableAppleIntelligence,
+  getAppleIntelligenceStatus,
   getAuthStatus,
   getModelSettings,
   loginWithChatgpt,
@@ -8,6 +10,7 @@ import {
   signOut,
   startXaiLogin,
   waitForXaiLogin,
+  type AppleIntelligenceStatus,
   type AuthStatus,
   type ModelSettings,
   type ProviderId,
@@ -84,15 +87,27 @@ export function Settings() {
 function AccountSection() {
   const [status, setStatus] = useState<AuthStatus | null>(null);
   const [models, setModels] = useState<ModelSettings | null>(null);
+  const [apple, setApple] = useState<AppleIntelligenceStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [xaiCode, setXaiCode] = useState<string | null>(null);
 
   const refresh = async () => {
     try {
-      const [s, m] = await Promise.all([getAuthStatus(), getModelSettings()]);
+      const [s, m, a] = await Promise.all([
+        getAuthStatus(),
+        getModelSettings(),
+        getAppleIntelligenceStatus().catch(
+          (): AppleIntelligenceStatus => ({
+            supported: false,
+            available: false,
+            reason: null,
+          }),
+        ),
+      ]);
       setStatus(s);
       setModels(m);
+      setApple(a);
     } catch {
       setStatus({
         signed_in: false,
@@ -128,7 +143,9 @@ function AccountSection() {
     setXaiCode(null);
     try {
       await signOut().catch(() => {});
-      if (provider === "chatgpt") {
+      if (provider === "apple_intelligence") {
+        await enableAppleIntelligence();
+      } else if (provider === "chatgpt") {
         await loginWithChatgpt();
       } else {
         const start = await startXaiLogin();
@@ -160,9 +177,12 @@ function AccountSection() {
   }
 
   const connected = status?.signed_in;
+  const isLocal = status?.provider === "apple_intelligence";
   const identity =
     status?.label ||
     (connected ? "Connected" : "Not connected");
+  const showModelPicker =
+    connected && models && models.models.length > 1 && !isLocal;
 
   return (
     <Section title="Account">
@@ -174,7 +194,7 @@ function AccountSection() {
       <Row label="Signed in as">
         <span className="text-[13px] text-[var(--text-soft)]">{identity}</span>
       </Row>
-      {connected && models && (
+      {showModelPicker && models && (
         <Row label="Model">
           <select
             value={models.selected}
@@ -190,6 +210,13 @@ function AccountSection() {
           </select>
         </Row>
       )}
+      {isLocal && (
+        <Row label="Model">
+          <span className="text-[13px] text-[var(--text-soft)]">
+            On-device (Apple Intelligence)
+          </span>
+        </Row>
+      )}
       {xaiCode && (
         <div className="px-5 py-3 text-[13px] text-[var(--text-soft)]">
           Enter code <span className="font-mono tracking-wider text-[var(--text)]">{xaiCode}</span> in
@@ -203,6 +230,16 @@ function AccountSection() {
         <div className="flex flex-wrap gap-2 justify-end">
           {!connected && (
             <>
+              {apple?.supported && (
+                <button
+                  disabled={busy || !apple.available}
+                  title={apple.available ? undefined : (apple.reason ?? undefined)}
+                  onClick={() => connect("apple_intelligence")}
+                  className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
+                >
+                  Apple Intelligence
+                </button>
+              )}
               <button
                 disabled={busy}
                 onClick={() => connect("chatgpt")}
@@ -221,21 +258,39 @@ function AccountSection() {
           )}
           {connected && (
             <>
-              <button
-                disabled={busy}
-                onClick={() =>
-                  connect(status?.provider === "chatgpt" ? "xai" : "chatgpt")
-                }
-                className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
-              >
-                Switch provider
-              </button>
+              {status?.provider !== "apple_intelligence" && apple?.supported && apple.available && (
+                <button
+                  disabled={busy}
+                  onClick={() => connect("apple_intelligence")}
+                  className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
+                >
+                  Switch to Apple
+                </button>
+              )}
+              {status?.provider !== "chatgpt" && (
+                <button
+                  disabled={busy}
+                  onClick={() => connect("chatgpt")}
+                  className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
+                >
+                  Switch to ChatGPT
+                </button>
+              )}
+              {status?.provider !== "xai" && (
+                <button
+                  disabled={busy}
+                  onClick={() => connect("xai")}
+                  className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
+                >
+                  Switch to SuperGrok
+                </button>
+              )}
               <button
                 disabled={busy}
                 onClick={handleSignOut}
                 className="text-[12.5px] px-3 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--sidebar)] cursor-pointer disabled:opacity-50"
               >
-                Sign out
+                {isLocal ? "Disconnect" : "Sign out"}
               </button>
             </>
           )}


### PR DESCRIPTION
## Summary

- Adds **Apple Intelligence** as a third proofreading provider (macOS 26+ Apple Silicon): fully on-device, no OAuth, text never leaves the machine.
- Implements a small local **Swift bridge** (`swift-bridge/AppleIntelligenceBridge.swift` + `build.rs` rpaths) instead of `foundation-models` on crates.io, which currently needs a newer Xcode SDK than many machines ship.
- Extends onboarding and Settings so users can pick Apple Intelligence, ChatGPT, or SuperGrok; local path reuses the existing system proofread prompt.
- Also includes prior branch commits needed as base: split inference module, and Input Monitoring + Accessibility permission handling for the global shortcut.

Closes #21

## Design notes

| Item | Choice |
|------|--------|
| Provider id | `apple_intelligence` |
| Auth | Tokenless session marker (“On this Mac”) |
| Inference | Fresh Foundation Models session per proofread |
| Availability | `apple_intelligence_status` / enable only when model is ready |
| Non-macOS | Commands/stubs compile out; cloud providers unchanged |

## Test plan

- [ ] `bun run tauri build` (or `cargo build --release` in `src-tauri`) on macOS 26 + Xcode 26
- [ ] Onboarding shows **Continue with Apple Intelligence** when available
- [ ] Settings can enable / switch to Apple Intelligence without browser login
- [ ] Double-tap Right Shift proofreads with Apple Intelligence selected (offline)
- [ ] ChatGPT and SuperGrok flows still work
- [ ] Unavailable AI (disabled / not downloaded) surfaces a clear error
- [ ] After install, Accessibility + Input Monitoring still required for the shortcut (re-grant after ad-hoc rebuilds)